### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,27 +34,27 @@ Building the extension
 Using it
 ==========================
 
-####Get similar labels:
+#### Get similar labels:
 
     curl --user neo4j:neo4j http://localhost:7474/service/graphify/similar/{label}
 
-####Train the natural language recognition model on text about 'Document classification':
+#### Train the natural language recognition model on text about 'Document classification':
 
     curl --user neo4j:neo4j -H "Content-Type: application/json" -d '{"label": ["Document classification"], "text": ["Documents may be classified according to their subjects or according to other attributes (such as document type, author, printing year etc.). In the rest of this article only subject classification is considered. There are two main philosophies of subject classification of documents: The content based approach and the request based approach."]}' http://localhost:7474/service/graphify/training
 
-####Classify an unlabeled text:
+#### Classify an unlabeled text:
 
     curl --user neo4j:neo4j -H "Content-Type: application/json" -d '{"text": "A document is a written or drawn representation of thoughts. Originating from the Latin Documentum meaning lesson - the verb means to teach, and is pronounced similarly, in the past it was usually used as a term for a written proof used as evidence."}' http://localhost:7474/service/graphify/classify
     
-####Get a list of the extracted semantic features matching a text:
+#### Get a list of the extracted semantic features matching a text:
 
     curl --user neo4j:neo4j -H "Content-Type: application/json" -d '{"text": "A document is a written or drawn representation of thoughts. Originating from the Latin Documentum meaning lesson - the verb means to teach, and is pronounced similarly, in the past it was usually used as a term for a written proof used as evidence."}' http://localhost:7474/service/graphify/extractfeatures
 
-####Get a sorted list of labels that are most related to the label 'Document classification':
+#### Get a sorted list of labels that are most related to the label 'Document classification':
 
     curl --user neo4j:neo4j http://localhost:7474/service/graphify/similar/Document%20classification
 
-#####Example response:
+##### Example response:
 
     {
         "classes": [


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
